### PR TITLE
Deprecate postprocessor and process_warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,37 +70,6 @@ periphery.scan do |violation|
 end
 ```
 
-### Postprocess warnings by calling `#process_warnings`
-
-You can modify warnings as you like by passing a block to `process_warnings`.
-`process_warnings` takes a block that receives `[path, line, column, message]` as arguments and returns one of the following types.
-
-- `Array` that exactly contains `[path, line, column, message]`
-- `true`
-- `false`
-- `nil`
-
-If an `Array` is returned, danger-periphery uses the values in an array instead of the raw result produced by Periphery.
-`true` has the same meaning as `[path, line, column, message]`, the argument array as-is.
-
-If it returns `false` or `nil`, the processing warning will be suppressed.
-
-For example, if you want your team members to be careful with warnings, the following code may work.
-
-```ruby
-periphery.process_warnings do |path, line, column, message|
-  [path, line, column, "Pay attention please! #{message}"]
-end
-```
-
-Or if you want to suppress all `unused` warnings, to return `nil` or `false` in the block works.
-
-```ruby
-periphery.process_warnings do |path, line, column, message|
-    !message.match(/unused/i)
-end
-```
-
 ## Development
 
 1. Clone this repo

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -36,7 +36,7 @@ module Danger
     #
     # By default the Proc returns true.
     # @return [Proc]
-    attr_accessor :postprocessor
+    attr_reader :postprocessor
 
     OPTION_OVERRIDES = {
       disable_update_check: true,
@@ -102,6 +102,17 @@ module Danger
       ].join
       Kernel.warn(message)
       @postprocessor = block
+    end
+
+    def postprocessor=(postprocessor)
+      message = [
+        "NOTE: #{self.class}##{__method__} is deprecated; ",
+        "use #{self.class}#scan with block instead. ",
+        "It will be removed from future releases.\n",
+        "#{self.class}##{__callee__} called from #{caller_locations(1, 1)[0]}"
+      ]
+      Kernel.warn(message)
+      @postprocessor = postprocessor
     end
 
     private

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -94,6 +94,13 @@ module Danger
     #     ! path.match(/.*\/generated\.swift/)
     #   end
     def process_warnings(&block)
+      message = [
+        "NOTE: #{self.class}##{__method__} is deprecated; ",
+        "use #{self.class}#scan with block instead. ",
+        "It will be removed from future releases.\n",
+        "#{self.class}##{__callee__} called from #{caller_locations(1, 1)[0]}"
+      ].join
+      Kernel.warn(message)
       @postprocessor = block
     end
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -94,24 +94,12 @@ module Danger
     #     ! path.match(/.*\/generated\.swift/)
     #   end
     def process_warnings(&block)
-      message = [
-        "NOTE: #{self.class}##{__method__} is deprecated; ",
-        "use #{self.class}#scan with block instead. ",
-        "It will be removed from future releases.\n",
-        "#{self.class}##{__callee__} called from #{caller_locations(1, 1)[0]}"
-      ].join
-      Kernel.warn(message)
+      deprecate_in_favor_of_scan
       @postprocessor = block
     end
 
     def postprocessor=(postprocessor)
-      message = [
-        "NOTE: #{self.class}##{__method__} is deprecated; ",
-        "use #{self.class}#scan with block instead. ",
-        "It will be removed from future releases.\n",
-        "#{self.class}##{__callee__} called from #{caller_locations(1, 1)[0]}"
-      ]
-      Kernel.warn(message)
+      deprecate_in_favor_of_scan
       @postprocessor = postprocessor
     end
 
@@ -149,6 +137,17 @@ module Danger
       else
         raise 'Proc passed to postprocessor must return one of nil, true, false and Array that includes 4 elements.'
       end
+    end
+
+    def deprecate_in_favor_of_scan
+      caller_method_name = caller(1, 1)[0].sub(/.*`(.*)'.*/, '\1')
+      message = [
+        "NOTE: #{self.class}##{caller_method_name} is deprecated; ",
+        "use #{self.class}#scan with block instead. ",
+        "It will be removed from future releases.\n",
+        "#{self.class}##{caller_method_name} called from #{caller_locations(2, 1)[0]}"
+      ]
+      Kernel.warn(message.join)
     end
   end
 end

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -23,6 +23,8 @@ module Danger
     # @return [String]
     attr_accessor :binary_path
 
+    # @deprecated Use {#scan} with block instead.
+    #
     # Proc object to process each warnings just before showing them.
     # The Proc must receive 4 arguments: path, line, column, message
     # and return one of:
@@ -85,14 +87,11 @@ module Danger
       end
     end
 
+    # @deprecated Use {#scan} with block instead.
+    #
     # Convenience method to set {#postprocessor} with block.
     #
     # @return [Proc]
-    #
-    # @example Ignore all warnings from files matching regular expression
-    #   periphery.process_warnings do |path, line, column, message|
-    #     ! path.match(/.*\/generated\.swift/)
-    #   end
     def process_warnings(&block)
       deprecate_in_favor_of_scan
       @postprocessor = block

--- a/spec/danger/danger_periphery_spec.rb
+++ b/spec/danger/danger_periphery_spec.rb
@@ -131,5 +131,9 @@ describe Danger::DangerPeriphery do
       end
       expect { periphery.process_warnings { |*_args| nil } }.to change(periphery, :postprocessor)
     end
+
+    it 'warns that it is deprecated' do
+      expect { periphery.process_warnings { |*_args| nil } }.to output(/NOTE:/).to_stderr
+    end
   end
 end

--- a/spec/danger/danger_periphery_spec.rb
+++ b/spec/danger/danger_periphery_spec.rb
@@ -126,7 +126,7 @@ describe Danger::DangerPeriphery do
 
   describe '#postprocessor=' do
     it 'warns that it is deprecated' do
-      expect { periphery.postprocessor = proc {} }.to output(/NOTE:/).to_stderr
+      expect { periphery.postprocessor = proc {} }.to output(/NOTE:.*postprocessor/).to_stderr
     end
   end
 
@@ -139,7 +139,7 @@ describe Danger::DangerPeriphery do
     end
 
     it 'warns that it is deprecated' do
-      expect { periphery.process_warnings { |*_args| nil } }.to output(/NOTE:/).to_stderr
+      expect { periphery.process_warnings { |*_args| nil } }.to output(/NOTE:.*process_warnings/).to_stderr
     end
   end
 end

--- a/spec/danger/danger_periphery_spec.rb
+++ b/spec/danger/danger_periphery_spec.rb
@@ -124,6 +124,12 @@ describe Danger::DangerPeriphery do
     end
   end
 
+  describe '#postprocessor=' do
+    it 'warns that it is deprecated' do
+      expect { periphery.postprocessor = proc {} }.to output(/NOTE:/).to_stderr
+    end
+  end
+
   describe '#process_warnings' do
     it 'sets postprocessor' do
       periphery.process_warnings do |_path, _line, _column, _message|


### PR DESCRIPTION
- Deprecate Danger::DangerPeriphery#process_warnings
- Deprecate Danger::DangerPeriphery#postprocessor=
- Remove instruction of deprecated methods from README
