### PR TITLE
Make integration specs faster

### DIFF
--- a/bin/generate-mock-periphery
+++ b/bin/generate-mock-periphery
@@ -38,6 +38,7 @@ Dir.mktmpdir do |derived_data_path|
          '-project', XCODEPROJ_PATH,
          '-scheme', 'test',
          '-configuration', 'Debug',
+         '-destination', 'platform=macOS',
          '-derivedDataPath', derived_data_path)
   index_store_path = File.join(derived_data_path, 'Index', 'DataStore')
   periphery_command = [PERIPHERY_PATH, 'scan',

--- a/spec/danger/danger_periphery_integration_spec.rb
+++ b/spec/danger/danger_periphery_integration_spec.rb
@@ -12,6 +12,7 @@ describe Danger::DangerPeriphery, :slow do
            '-project', fixture('test.xcodeproj'),
            '-scheme', 'test',
            '-configuration', 'Debug',
+           '-destination', 'platform=macOS',
            '-derivedDataPath', @derived_data_path)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@
 ROOT = Pathname.new(File.expand_path('..', __dir__))
 $LOAD_PATH.unshift("#{ROOT}lib".to_s, "#{ROOT}spec".to_s)
 
-require 'bundler/setup'
 require 'danger'
 require 'pry'
 require 'rspec'


### PR DESCRIPTION
- Use cached index store path
- Remove redundant bundler/setup
- Add missing destination for xcodebuild
