### PR TITLE
Introduce option to treat all warnings as errors

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -50,7 +50,7 @@ guard :rspec, cmd: 'bundle exec rspec -t ~slow', run_all: { cmd: 'bundle exec rs
   dsl.watch_spec_files_for(ruby.lib_files)
 end
 
-guard :rubocop do
+guard :rubocop, all_on_start: false, cli: '-D' do
   watch(/.+\.rb$/)
   watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
 end

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ periphery.scan_all_files = true
 periphery.scan
 ```
 
+You can force `danger-periphery` treat all warnings as errors by changing `warning_as_error` flag.
+
+```ruby
+periphery.warning_as_error = true
+periphery.scan
+```
+
 ## Advanced Usage
 
 ### Skip building for faster analysis

--- a/lib/danger/danger_periphery.rb
+++ b/lib/danger/danger_periphery.rb
@@ -102,7 +102,7 @@ module Danger
     private
 
     def report(*args, **kwargs)
-      return fail(*args, **kwargs) if warning_as_error
+      return self.fail(*args, **kwargs) if warning_as_error
 
       warn(*args, **kwargs)
     end

--- a/lib/danger/danger_periphery.rb
+++ b/lib/danger/danger_periphery.rb
@@ -29,6 +29,12 @@ module Danger
     #                   By default +false+ is set.
     attr_accessor :scan_all_files
 
+    # A flag to treat warnings as errors.
+    # @return [Boolean] +true+ if this plugin reports all violations as errors.
+    #                   Otherwise +false+, it reports violations as warnings.
+    #                   By default +false+ is set.
+    attr_accessor :warning_as_error
+
     # For internal use only.
     #
     # @return [Symbol]
@@ -42,6 +48,7 @@ module Danger
     def initialize(dangerfile)
       super(dangerfile)
       @format = :checkstyle
+      @warning_as_error = false
     end
 
     # Scans Swift files.
@@ -75,7 +82,7 @@ module Danger
 
         next if block_given? && !yield(entry)
 
-        warn(entry.message, file: entry.path, line: entry.line)
+        report(entry.message, file: entry.path, line: entry.line)
       end
     end
 
@@ -93,6 +100,12 @@ module Danger
     end
 
     private
+
+    def report(*args, **kwargs)
+      return fail(*args, **kwargs) if warning_as_error
+
+      warn(*args, **kwargs)
+    end
 
     def files_in_diff
       # Taken from https://github.com/ashfurrow/danger-ruby-swiftlint/blob/5184909aab00f12954088684bbf2ce5627e08ed6/lib/danger_plugin.rb#L214-L216

--- a/spec/danger/danger_periphery_spec.rb
+++ b/spec/danger/danger_periphery_spec.rb
@@ -137,6 +137,39 @@ describe Danger::DangerPeriphery do
     end
   end
 
+  describe '#warning_as_error' do
+    subject(:errors) { dangerfile.status_report[:errors] }
+
+    before do
+      periphery.warning_as_error = warning_as_error
+      periphery.scan
+    end
+
+    context 'with false' do
+      let(:warning_as_error) { false }
+
+      it 'reports violations as warnings' do
+        expect(warnings).not_to be_empty
+      end
+
+      it 'does not report any errors' do
+        expect(errors).to be_empty
+      end
+    end
+
+    context 'with true' do
+      let(:warning_as_error) { true }
+
+      it 'reports violations as errors' do
+        expect(errors).not_to be_empty
+      end
+
+      it 'does not warn anything' do
+        expect(warnings).to be_empty
+      end
+    end
+  end
+
   describe '#format' do
     subject(:parser) { periphery.send(:parser) }
 


### PR DESCRIPTION
Close #198

Added `warning_as_error` flag to treat all warnings as errors.
