### PR TITLE
Add Support for build_args in scan Method for Custom xcodebuild Arguments

### DIFF
--- a/lib/periphery/runner.rb
+++ b/lib/periphery/runner.rb
@@ -13,6 +13,12 @@ module Periphery
 
     def scan(options)
       arguments = [binary_path, 'scan'] + scan_arguments(options)
+
+      if options[:build_args]
+        arguments << "--"
+        arguments += Array(options[:build_args])
+      end
+
       stdout, stderr, status = Open3.capture3(*arguments)
       raise "error: #{arguments} exited with status code #{status.exitstatus}. #{stderr}" unless status.success?
 
@@ -20,22 +26,29 @@ module Periphery
     end
 
     def scan_arguments(options)
-      options.each_with_object([]) do |(key, value), new_options|
+      args = []
+
+      options.each do |key, value|
         next unless value
+
+        next if key == :build_args
 
         value = nil if value.is_a?(TrueClass)
         if value.is_a?(Array)
           if Gem::Version.new(version) >= Gem::Version.new('2.18.0')
-            new_options << "--#{key.to_s.tr('_', '-')}"
-            new_options.push(*value.map(&:to_s))
-            next
+            args << "--#{key.to_s.tr('_', '-')}"
+            args.push(*value.map(&:to_s))
           else
-            value = value.join(',')
+            args << "--#{key.to_s.tr('_', '-')}"
+            args << value.join(',')
           end
+        else
+          args << "--#{key.to_s.tr('_', '-')}"
+          args << value&.to_s if value
         end
-        new_options << "--#{key.to_s.tr('_', '-')}"
-        new_options << value&.to_s if value
       end
+
+      args
     end
 
     def version


### PR DESCRIPTION
### Key Changes:
- **New Argument:** Added `build_args` to the `scan` method, allowing users to specify arguments for `xcodebuild`.
- **Handling Arguments:** If `build_args` is provided, these arguments are appended to the command after `--`, following the standard convention for passing additional arguments to `xcodebuild`.

### Example Usage:
```ruby
periphery.scan(
  config: '.periphery.yml', 
  project: 'MyProject.xcworkspace', 
  build_args: " -destination 'platform=iOS Simulator,name=iPhone 15 Pro Max' DISABLE_SWIFTLINT=YES"
)
```

Please review the changes, and I look forward to your feedback!

**Thank you!**